### PR TITLE
Add forced-host check (workaround)

### DIFF
--- a/src/main/java/com/mattmx/reconnect/listener/Listener.java
+++ b/src/main/java/com/mattmx/reconnect/listener/Listener.java
@@ -19,7 +19,9 @@ import net.kyori.adventure.audience.MessageType;
 import org.simpleyaml.configuration.Configuration;
 import org.simpleyaml.configuration.file.FileConfiguration;
 import org.simpleyaml.configuration.file.YamlConfiguration;
+import org.slf4j.Logger;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
@@ -29,6 +31,7 @@ public class Listener {
 
     @Subscribe
     public void choose(PlayerChooseInitialServerEvent e) {
+        if (isForcedHost(e)) return;
         Player player = e.getPlayer();
         String prev = ReconnectVelocity.get().getStorageManager().get().getLastServer(player.getUniqueId().toString());
         RegisteredServer server;
@@ -64,6 +67,47 @@ public class Listener {
                 }
             }
         }
+    }
+
+    private boolean isForcedHost(PlayerChooseInitialServerEvent e) {
+        Logger logger = ReconnectVelocity.get().logger();
+
+        List<String> attemptConnectionOrder = ReconnectVelocity.get().getServer()
+                .getConfiguration().getAttemptConnectionOrder();
+        Optional<String> defaultServerOptional = getFirstAvailableServer(attemptConnectionOrder);
+        logger.debug("Default server: {}", defaultServerOptional);
+
+        Optional<RegisteredServer> joiningServerOptional = e.getInitialServer();
+        logger.debug("Joining server: {}", joiningServerOptional);
+
+        if (joiningServerOptional.isPresent() && defaultServerOptional.isPresent()) {
+            if (joiningServerOptional.get().getServerInfo().getName().equals(defaultServerOptional.get())) {
+                logger.debug("Player connecting to default server {}, assuming not a forced host",
+                        defaultServerOptional.get());
+                // TODO: It's possible that the player is connecting to the default server on purpose i.e.
+                //  via a forced host. This method won't work in that case.
+            } else {
+                logger.debug("Player connecting to non-default server {}, is forced host",
+                        joiningServerOptional.get().getServerInfo().getName());
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private Optional<String> getFirstAvailableServer(List<String> serverList) {
+        for (String server : serverList) {
+            try {
+                final RegisteredServer registeredServer = ReconnectUtil.getServer(server);
+                if (registeredServer != null) {
+                    registeredServer.ping();
+                    return Optional.of(server);
+                }
+            } catch (CancellationException | CompletionException ignored) {
+            }
+        }
+        return Optional.empty();
     }
 
     @Subscribe


### PR DESCRIPTION
Closes #8 with a workaround:
Players will be able to connect to all forced hosts except those that point to your default server. This usually is(are) your lobby server(s).